### PR TITLE
Fix MavensMate issue 402

### DIFF
--- a/mm/sforce/metadata.py
+++ b/mm/sforce/metadata.py
@@ -265,7 +265,15 @@ class SforceMetadataClient(SforceBaseClient):
         if retXml == True:
             try:
                 list_result_dict = xmltodict.parse(list_result,postprocessor=util.xmltodict_postprocessor)
-                return list_result_dict['soapenv:Envelope']["soapenv:Body"]["listMetadataResponse"]["result"]
+                result = list_result_dict['soapenv:Envelope']["soapenv:Body"]["listMetadataResponse"]["result"]
+                # for namespaced layouts, listMetadata doesn't return the correct name
+                # we need to prepend the namespacePrefix to the layout name
+                if metadata_type == 'Layout':
+                    for d in result:
+                        if 'namespacePrefix' in d:
+                            d['fullName'] = d['fullName'].replace('-', '-'+d['namespacePrefix']+'__', 1)
+                            d['fileName'] = d['fileName'].replace('-', '-'+d['namespacePrefix']+'__', 1)
+                return result
             except:
                 return []
         return list_result


### PR DESCRIPTION
Salesforce Metadata API's listMetadata call doesn't seem to return valid names for layouts in a managed package. This prepends the package namespace to the layout name in the listMetadata call so that retrieving the layouts via MavensMate works correctly.

This fixes MavensMate issue 402

https://github.com/joeferraro/MavensMate/issues/402