### PR TITLE
get test suite passing 

### DIFF
--- a/mm/project.py
+++ b/mm/project.py
@@ -1089,7 +1089,7 @@ class MavensMateProject(object):
         default_levels = {
             "Database"      : "INFO",
             "System"        : "DEBUG",
-            "Visualforce"   : "DEBUG",
+            "Visualforce"   : "INFO",
             "Workflow"      : "INFO",
             "Validation"    : "INFO",
             "Callout"       : "INFO",

--- a/test/functional/debug/log_tests.py
+++ b/test/functional/debug/log_tests.py
@@ -14,7 +14,7 @@ class StackTraceAndLogsTest(MavensMateTest):
         stdin = {
             "project_name"      : "unit test tooling project"
         }
-        mm_response = self.runCommand('delete_trace_flags', stdin)        
+        mm_response = self.runCommand('delete_trace_flags', stdin)
         self.assertTrue(mm_response['success'] == True)
 
     def test_02_should_create_new_trace_flag(self): 
@@ -26,11 +26,21 @@ class StackTraceAndLogsTest(MavensMateTest):
                 "Visualforce"   : "INFO"
             }
         }
-        mm_response = self.runCommand('new_log', stdin)        
+        mm_response = self.runCommand('new_log', stdin)
         self.assertTrue(mm_response['success'] == True)
         self.assertTrue('id' in mm_response and len(mm_response['id']) is 18)
 
     def test_03_should_create_new_quicklog(self): 
+        # need to delete existing trace flag first (since there
+        # can only be one TraceLog per TracedEntityId), NB: in 
+        # some cases salesforce doesn't seem to check this, but 
+        # it's not consistent
+        stdin = {
+            "project_name"      : "unit test tooling project"
+        }
+        mm_response = self.runCommand('delete_trace_flags', stdin)
+        self.assertTrue(mm_response['success'] == True)
+        
         stdin = {
             "project_name"      : "unit test tooling project",
             "type"              : "user",
@@ -48,7 +58,7 @@ class StackTraceAndLogsTest(MavensMateTest):
             "project_name"      : "unit test tooling project"
         }
         mm_response = self.runCommand('get_trace_flags', stdin)
-        self.assertTrue(mm_response['totalSize'] == 2)
+        self.assertTrue(mm_response['totalSize'] == 1)
         self.assertTrue(mm_response['entityTypeName'] == 'TraceFlag')
         self.assertTrue(mm_response['done'] == True)
 


### PR DESCRIPTION
test should have been failing the entire time, it's not clear why it wasn't since `test_02_should_create_new_trace_flag` and `test_03_should_create_new_quicklog` both create TraceLog records with the same `scopeId` and `tracedEntityId`, best guess is that salesforce code enforcing this has some issues since the behavior is fairly bizarre

while i'm in there, adjust the default logging level for visualforce to be a valid option

